### PR TITLE
Improved version detection and player loss fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.3] - 2020-01-21
+
+### Fixed
+
+- Fix the problem when the Gauges lost the player
+
+### Changed
+
+- Now the Minetest version is checked using `minetest.get_version()`. It is very reliable.
+
 ## [1.0.2] - 2020-01-16
 
 ### Fixed
@@ -29,3 +39,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/minetest-mods/gauges/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/minetest-mods/gauges/compare/v1.0.0...v1.0.1
+[1.0.2]: https://github.com/minetest-mods/gauges/compare/v1.0.1...v1.0.2
+[1.0.3]: https://github.com/minetest-mods/gauges/compare/v1.0.2...v1.0.3

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ on that line.
 
 ## Version compatibility
 
-Gauges is currently primarily tested with Minetest 5.1.0 and 0.4.17. It may or may not work
-with newer or older versions. Issues arising in versions older than 5.0.0
+Gauges is currently support Minetest 5.0+ and 0.4.17+. This does not work with older versions.
+Issues arising in versions older than 5.0
 will generally not be fixed.
 
 ## License

--- a/init.lua
+++ b/init.lua
@@ -50,8 +50,13 @@ minetest.register_entity("gauges:hp_bar", {
 local function add_gauge(player)
 	if player and minetest.is_player(player) then
 		local entity = minetest.add_entity(player:get_pos(), "gauges:hp_bar")
-		-- check for minetest_game 0.4.*
-		local height = minetest.get_modpath("player_api") and 19 or 9
+		local height = 19
+
+		-- check for Minetest 0.4.17
+		local version = tonumber(minetest.get_version().string:sub(1, 1))
+		if version and version < 5 then
+			height = 9
+		end
 
 		entity:set_attach(player, "", {x=0, y=height, z=0}, {x=0, y=0, z=0})
 		entity:get_luaentity().wielder = player

--- a/init.lua
+++ b/init.lua
@@ -7,48 +7,12 @@ if minetest.settings:get_bool("health_bars") == false or
 		not minetest.settings:get_bool("enable_damage")
 then return end
 
--- Localize the vector distance function for better performance, as it's called
--- on every step
+-- Localize the vector distance function for better performance,
+-- as it's called on every step
 local vector_distance = vector.distance
 
-minetest.register_entity("gauges:hp_bar", {
-	visual = "sprite",
-	visual_size = {x=1, y=1/16, z=1},
-	-- The texture is changed later in the code
-	textures = {"blank.png"},
-	collisionbox = {0},
-	physical = false,
-
-	on_step = function(self)
-		local player = self.wielder
-		local gauge = self.object
-
-		if not player or
-				not minetest.is_player(player) or
-				vector_distance(player:get_pos(), gauge:get_pos()) > 3
-		then
-			gauge:remove()
-			return
-		end
-
-		local hp = player:get_hp() <= 20 and player:get_hp() or 20
-		local breath = player:get_breath() <= 10 and player:get_breath() or 11
-
-		if self.hp ~= hp or self.breath ~= breath then
-			gauge:set_properties({
-				textures = {
-					"health_"..tostring(hp)..".png^"..
-					"breath_"..tostring(breath)..".png"
-				}
-			})
-			self.hp = hp
-			self.breath = breath
-		end
-	end
-})
-
 local function add_gauge(player)
-	if player and minetest.is_player(player) then
+	if player and player:is_player() then
 		local entity = minetest.add_entity(player:get_pos(), "gauges:hp_bar")
 		local height = 19
 
@@ -62,6 +26,42 @@ local function add_gauge(player)
 		entity:get_luaentity().wielder = player
 	end
 end
+
+minetest.register_entity("gauges:hp_bar", {
+	visual = "sprite",
+	visual_size = {x=1, y=1/16, z=1},
+	textures = {"blank.png"},
+	collisionbox = {0},
+	physical = false,
+
+	on_step = function(self)
+		local player = self.wielder
+		local gauge = self.object
+
+		if not player or not player:is_player() then
+			gauge:remove()
+			return
+		elseif vector_distance(player:get_pos(), gauge:get_pos()) > 3 then
+			gauge:remove()
+			add_gauge(player)
+			return
+		end
+
+		local hp = player:get_hp() <= 20 and player:get_hp() or 20
+		local breath = player:get_breath() <= 10 and player:get_breath() or 11
+
+		if self.hp ~= hp or self.breath ~= breath then
+			gauge:set_properties({
+				textures = {
+					"health_"..hp..".png^"..
+					"breath_"..breath..".png"
+				}
+			})
+			self.hp = hp
+			self.breath = breath
+		end
+	end
+})
 
 minetest.register_on_joinplayer(function(player)
 	minetest.after(1, add_gauge, player)


### PR DESCRIPTION
1) Tested support for older versions. Only 0.4.17 is supported. Older versions do not support `is_player`, I see no reason to adding hack for this.
2) On my server, I noticed some players without Gauges. I hope my fix should resolve this (not sure).

*Edit: This closes #6.*