### PR TITLE
Don't lose hp_bar when teleporting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -45,6 +45,7 @@ minetest.register_entity("gauges:hp_bar", {
 	textures = {"blank.png"},
 	collisionbox = {0},
 	physical = false,
+	static_save = false,
 
 	on_step = function(self)
 		local player = self.wielder


### PR DESCRIPTION
If a player teleports far away, their hp_bar can become deactivated and disappear. The mod installs the gauge only when a player joins, so it will be forever missing. `static_save = false` prevents the item from deactivating https://github.com/minetest/minetest/blob/master/src/serverenvironment.cpp#L2028 .
Also, it doesn't make sense to save `gauges:hp_bar` to map meta since it's not a standalone item.